### PR TITLE
Use curl instead of wget because it is not bundled in self-hosted run…

### DIFF
--- a/scripts/unixish.sh
+++ b/scripts/unixish.sh
@@ -74,7 +74,7 @@ echo '::group::Downloading yq'
 echo "Src: ${_dl_url}"
 echo "Dst: ${_dl_path}"
 
-wget -O- "${_dl_url}" > "${_dl_path}"
+curl -L "${_dl_url}" -o "${_dl_path}"
 
 echo '::endgroup::'
 


### PR DESCRIPTION
…ner image

Like in the https://github.com/dcarbone/install-jq-action/pull/8/files
we need to change it here as well. Current runner image doesn't include `wget` https://github.com/actions/runner/releases/tag/v2.320.0